### PR TITLE
reからfnmatchに変更

### DIFF
--- a/pyzipper/zipper.py
+++ b/pyzipper/zipper.py
@@ -2,11 +2,11 @@
 from pathlib import Path
 from typing import List
 import zipfile
-import re
+import fnmatch
 
 def is_match(name: str, patterns: List[str]):
     for pattern in patterns:
-        if re.match(pattern, name):
+        if fnmatch.fnmatch(name, pattern):
             return True
     
     return False


### PR DESCRIPTION
reではなく、ファイル名のマッチングにはfnmatchの方が適している。
これはテストをパスします。